### PR TITLE
Fixed order of 'summary' and 'reference' arguments.

### DIFF
--- a/files2rouge/files2rouge.py
+++ b/files2rouge/files2rouge.py
@@ -95,8 +95,8 @@ def main():
     parser.add_argument("-i", "--ignore_empty", action="store_true")
     args = parser.parse_args()
 
-    run(args.reference,
-        args.summary,
+    run(args.summary,
+        args.reference,
         args.args,
         args.verbose,
         args.saveto,


### PR DESCRIPTION
Before this change, the summary was regarded as reference and vice
versa. As a result, precision and recall results were switched
(F-score is unaffected).

Test with two files foo.ref and foo.sum:

```
==> foo.ref <==
1 2 3 4 5

==> foo.sum <==
2 3 4

Before the change:

$ files2rouge foo.ref foo.sum
Preparing documents... 0 line(s) ignored
Running ROUGE...
---------------------------------------------
1 ROUGE-1 Average_R: 1.00000 (95%-conf.int. 1.00000 - 1.00000)
1 ROUGE-1 Average_P: 0.60000 (95%-conf.int. 0.60000 - 0.60000)
1 ROUGE-1 Average_F: 0.75000 (95%-conf.int. 0.75000 - 0.75000)
---------------------------------------------
1 ROUGE-2 Average_R: 1.00000 (95%-conf.int. 1.00000 - 1.00000)
1 ROUGE-2 Average_P: 0.50000 (95%-conf.int. 0.50000 - 0.50000)
1 ROUGE-2 Average_F: 0.66667 (95%-conf.int. 0.66667 - 0.66667)
---------------------------------------------
1 ROUGE-L Average_R: 1.00000 (95%-conf.int. 1.00000 - 1.00000)
1 ROUGE-L Average_P: 0.60000 (95%-conf.int. 0.60000 - 0.60000)
1 ROUGE-L Average_F: 0.75000 (95%-conf.int. 0.75000 - 0.75000)

After the change:

$ files2rouge foo.ref foo.sum
Preparing documents... 0 line(s) ignored
Running ROUGE...
---------------------------------------------
1 ROUGE-1 Average_R: 0.60000 (95%-conf.int. 0.60000 - 0.60000)
1 ROUGE-1 Average_P: 1.00000 (95%-conf.int. 1.00000 - 1.00000)
1 ROUGE-1 Average_F: 0.75000 (95%-conf.int. 0.75000 - 0.75000)
---------------------------------------------
1 ROUGE-2 Average_R: 0.50000 (95%-conf.int. 0.50000 - 0.50000)
1 ROUGE-2 Average_P: 1.00000 (95%-conf.int. 1.00000 - 1.00000)
1 ROUGE-2 Average_F: 0.66667 (95%-conf.int. 0.66667 - 0.66667)
---------------------------------------------
1 ROUGE-L Average_R: 0.60000 (95%-conf.int. 0.60000 - 0.60000)
1 ROUGE-L Average_P: 1.00000 (95%-conf.int. 1.00000 - 1.00000)
1 ROUGE-L Average_F: 0.75000 (95%-conf.int. 0.75000 - 0.75000)
```