### PR TITLE
Fix bug: KeyError: 'HOME' in Windows.

### DIFF
--- a/setup_rouge.py
+++ b/setup_rouge.py
@@ -12,7 +12,10 @@ from six.moves import input
 
 
 def copy_rouge():
-    home = os.environ['HOME']
+    if 'HOME' not in os.environ:
+        home = os.environ['HOMEPATH']
+    else:
+        home = os.environ['HOME']
 
     src_rouge_root = "./files2rouge/RELEASE-1.5.5/"
 


### PR DESCRIPTION
In Windows OS, os.environ does not have key "HOME" instead of "HOMEPATH".